### PR TITLE
Add images to replace gray blocks

### DIFF
--- a/src/app/components/AboutUs.tsx
+++ b/src/app/components/AboutUs.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export default function AboutUs() {
   return (
     <section className="max-w-7xl mx-auto px-4 sm:px-6 py-16">
@@ -13,7 +15,13 @@ export default function AboutUs() {
       <div className="mt-10 flex flex-col lg:flex-row gap-10 items-start">
         {/* IMAGEM */}
         <div className="flex-1 w-full">
-          <div className="w-full h-60 sm:h-80 md:h-96 bg-gray-300 rounded-2xl transition-transform duration-300 hover:scale-105" />
+          <Image
+            src="/images/image-5.jpg"
+            alt="Equipe trabalhando"
+            width={800}
+            height={400}
+            className="w-full h-60 sm:h-80 md:h-96 rounded-2xl object-cover transition-transform duration-300 hover:scale-105"
+          />
         </div>
 
         {/* TEXTO LATERAL */}

--- a/src/app/components/ContactCta.tsx
+++ b/src/app/components/ContactCta.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export default function ContactCta() {
   return (
     <section className="max-w-7xl mx-auto px-6 py-16">
@@ -45,8 +47,14 @@ export default function ContactCta() {
         </div>
 
         {/* BLOCO ILUSTRATIVO */}
-        <div className="w-full sm:w-64 h-48 bg-gray-300 rounded-xl flex items-center justify-center text-gray-500 text-sm">
-          Imagem de climatização aqui
+        <div className="w-full sm:w-64 h-48 rounded-xl overflow-hidden">
+          <Image
+            src="/images/image-1.png"
+            alt="Entre em contato"
+            width={256}
+            height={192}
+            className="w-full h-48 object-cover"
+          />
         </div>
       </div>
     </section>

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -49,7 +49,13 @@ export default function Hero() {
                 height={20}
                 className="rounded-3xl w-full object-cover"
               />
-              <div className="w-1/2 h-20 bg-gray-200 rounded-lg" />
+              <Image
+                src="/images/image-2.jpg"
+                alt="Instalação em andamento"
+                width={80}
+                height={80}
+                className="w-1/2 h-20 rounded-lg object-cover"
+              />
             </div>
             <div className="w-8 h-8 bg-black rounded-full flex items-center justify-center mt-4 hover:bg-orange-500 transition">
               <ArrowUpRight className="text-white w-4 h-4" />
@@ -62,8 +68,20 @@ export default function Hero() {
               Manutenção preventiva para garantir o melhor desempenho
             </p>
             <div className="flex mt-4 gap-2">
-              <div className="w-1/2 h-20 bg-gray-300 rounded-lg" />
-              <div className="w-1/2 h-20 bg-gray-200 rounded-lg" />
+              <Image
+                src="/images/image-3.png"
+                alt="Manutenção"
+                width={80}
+                height={80}
+                className="w-1/2 h-20 rounded-lg object-cover"
+              />
+              <Image
+                src="/images/image-4.jpeg"
+                alt="Equipamento"
+                width={80}
+                height={80}
+                className="w-1/2 h-20 rounded-lg object-cover"
+              />
             </div>
             <div className="w-8 h-8 bg-black rounded-full flex items-center justify-center mt-4 hover:bg-orange-500 transition">
               <ArrowUpRight className="text-white w-4 h-4" />
@@ -74,15 +92,13 @@ export default function Hero() {
 
       {/* DIREITA */}
       <div className="flex-1 w-full">
-        {/* Substitua por uma imagem real se desejar */}
-        <div className="w-full h-64 sm:h-80 md:h-[400px] rounded-3xl bg-gray-300" />
-        {/* <Image
-          src="/capa-ar-condicionado.png"
-          alt="Imagem climatização"
+        <Image
+          src="/images/sala-ar2.jpg"
+          alt="Climatização em destaque"
           width={500}
           height={400}
-          className="rounded-3xl w-full object-cover"
-        /> */}
+          className="w-full h-64 sm:h-80 md:h-[400px] rounded-3xl object-cover"
+        />
       </div>
     </section>
   );

--- a/src/app/components/Services.tsx
+++ b/src/app/components/Services.tsx
@@ -1,4 +1,5 @@
 import { Wrench, RefreshCcw, Wind, Ruler } from "lucide-react";
+import Image from "next/image";
 
 export default function Services() {
   return (
@@ -70,7 +71,13 @@ export default function Services() {
 
         {/* BLOCO DE VÍDEO */}
         <div className="col-span-full lg:col-span-2">
-          <div className="relative w-full h-52 sm:h-64 bg-gray-300 rounded-2xl overflow-hidden hover:scale-105 transition-transform duration-300">
+          <div className="relative w-full h-52 sm:h-64 rounded-2xl overflow-hidden hover:scale-105 transition-transform duration-300">
+            <Image
+              src="/images/image-7.jpg"
+              alt="Demonstração de serviço"
+              fill
+              className="object-cover"
+            />
             <div className="absolute inset-0 flex items-center justify-center">
               <button className="w-12 h-12 bg-white text-orange-500 rounded-full shadow-md flex items-center justify-center hover:ring-2 hover:ring-orange-400 transition">
                 ▶

--- a/src/app/components/Testimonials.tsx
+++ b/src/app/components/Testimonials.tsx
@@ -1,5 +1,6 @@
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination, Autoplay } from "swiper/modules";
+import Image from "next/image";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
@@ -27,7 +28,13 @@ export default function Testimonials() {
       <div className="flex flex-col lg:flex-row items-center gap-12">
         {/* IMAGEM ILUSTRATIVA */}
         <div className="flex-1 w-full">
-          <div className="w-full h-64 sm:h-80 bg-gray-300 rounded-xl" />
+          <Image
+            src="/images/image-8.jpg"
+            alt="Clientes satisfeitos"
+            width={500}
+            height={320}
+            className="w-full h-64 sm:h-80 rounded-xl object-cover"
+          />
         </div>
 
         {/* CONTEÚDO */}

--- a/src/app/components/WhoWeAre.tsx
+++ b/src/app/components/WhoWeAre.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle } from "lucide-react";
+import Image from "next/image";
 
 export default function WhoWeAre() {
   return (
@@ -9,7 +10,13 @@ export default function WhoWeAre() {
       <section className="relative max-w-7xl mx-auto px-6 py-16 md:py-20 flex flex-col lg:flex-row items-center gap-12">
         {/* IMAGEM */}
         <div className="flex-1 z-10 w-full">
-          <div className="w-full h-52 sm:h-72 md:h-80 lg:h-96 bg-gray-300 rounded-xl transition-transform hover:scale-105 duration-300" />
+          <Image
+            src="/images/image-6.jpg"
+            alt="Nossa equipe"
+            width={600}
+            height={400}
+            className="w-full h-52 sm:h-72 md:h-80 lg:h-96 rounded-xl object-cover transition-transform hover:scale-105 duration-300"
+          />
         </div>
 
         {/* TEXTO */}


### PR DESCRIPTION
## Summary
- replace gray placeholders with images from `public/images`
- import `next/image` where needed

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6850550b2c58832587cca35265c4328c